### PR TITLE
Create ShanghaiTech-802.1x-nmcli.fish

### DIFF
--- a/Shell/ShanghaiTech-802.1x-nmcli.fish
+++ b/Shell/ShanghaiTech-802.1x-nmcli.fish
@@ -1,0 +1,18 @@
+#!/usr/bin/fish
+# credit: https://campus-rover.gitbook.io/lab-notebook/infrastructure/linux_terminal_eduroam_setup
+
+set student_id   "for example 2090335114"
+set ids_password 'your password for https://ids.shanghaitech.edu.cn/'
+
+nmcli connection add \
+	type wifi \
+	con-name "ShanghaiTech" \
+	ifname wlp1s0 \
+	ssid "ShanghaiTech" \
+	wifi-sec.key-mgmt wpa-eap \
+	802-1x.identity "$student_id" \
+	802-1x.password "$ids_password" \
+	802-1x.system-ca-certs yes \
+	802-1x.eap "peap" \
+	802-1x.phase2-auth mschapv2
+nmcli connection up ShanghaiTech

--- a/Shell/ShanghaiTech-802.1x-nmcli.fish
+++ b/Shell/ShanghaiTech-802.1x-nmcli.fish
@@ -4,6 +4,7 @@
 set student_id   "for example 2090335114"
 set ids_password 'your password for https://ids.shanghaitech.edu.cn/'
 
+nmcli connection delete ShanghaiTech
 nmcli connection add \
 	type wifi \
 	con-name "ShanghaiTech" \


### PR DESCRIPTION
Use `nmcli` to configure and connect to WiFi `SSID=ShanghaiTech`.  
After WiFi connection and authentication scheme changed on 2022-11-04 (date format YYYY-MM-DD).